### PR TITLE
multiple checkers

### DIFF
--- a/src/main/java/nanoquiz/QuestionLoader.java
+++ b/src/main/java/nanoquiz/QuestionLoader.java
@@ -6,7 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 
-import nanoquiz.checker.CaseInsensitiveAnswerChecker;
+import nanoquiz.checker.AnswerCheckerMaker;
 
 public abstract class QuestionLoader {
     static void loadQuestions() {
@@ -30,7 +30,7 @@ public abstract class QuestionLoader {
                 if (question == null || answer == null) {
                     break;
                 }
-                Main.questions.add(new Question(question, new CaseInsensitiveAnswerChecker(answer)));
+                Main.questions.add(new Question(question, AnswerCheckerMaker.parseAnswer(answer)));
             }
         } catch(IOException e) {
             e.printStackTrace();

--- a/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
+++ b/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
@@ -23,7 +23,7 @@ public interface AnswerCheckerMaker {
 		if(end == -1)
 			return new CaseInsensitiveAnswerChecker(input);
 		
-		String checkerName = input.substring(1, end);
+		String checkerName = input.substring(1, end).toLowerCase();
 		AnswerCheckerMaker checkerType = makers.get(checkerName);
 		if(checkerType == null)
 			return new CaseInsensitiveAnswerChecker(input);

--- a/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
+++ b/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
@@ -10,7 +10,9 @@ public interface AnswerCheckerMaker {
 	public static final Map<String, AnswerCheckerMaker> makers = Map.<String, AnswerCheckerMaker>ofEntries(
 		new AbstractMap.SimpleImmutableEntry<>("ci", CaseInsensitiveAnswerChecker::new),
 		new AbstractMap.SimpleImmutableEntry<>("case_insensitive", CaseInsensitiveAnswerChecker::new),
-		new AbstractMap.SimpleImmutableEntry<>("literal", LiteralAnswerChecker::new)
+		new AbstractMap.SimpleImmutableEntry<>("literal", LiteralAnswerChecker::new),
+		new AbstractMap.SimpleImmutableEntry<>("cs", CaseSensitiveAnswerChecker::new),
+		new AbstractMap.SimpleImmutableEntry<>("case_sensitive", CaseSensitiveAnswerChecker::new)
 	);
 
 	public static AnswerChecker parseAnswer(String input) {

--- a/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
+++ b/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
@@ -1,0 +1,31 @@
+package nanoquiz.checker;
+
+import java.util.AbstractMap;
+import java.util.Map;
+
+@FunctionalInterface
+public interface AnswerCheckerMaker {
+	AnswerChecker make(String correctAnswer);
+
+	public static final Map<String, AnswerCheckerMaker> makers = Map.<String, AnswerCheckerMaker>ofEntries(
+		new AbstractMap.SimpleImmutableEntry<>("ci", CaseInsensitiveAnswerChecker::new),
+		new AbstractMap.SimpleImmutableEntry<>("case_insensitive", CaseInsensitiveAnswerChecker::new),
+		new AbstractMap.SimpleImmutableEntry<>("literal", LiteralAnswerChecker::new)
+	);
+
+	public static AnswerChecker parseAnswer(String input) {
+		if(input.charAt(0) != '(')
+			return new CaseInsensitiveAnswerChecker(input);
+
+		int end = input.indexOf(')');
+		if(end == -1)
+			return new CaseInsensitiveAnswerChecker(input);
+		
+		String checkerName = input.substring(1, end);
+		AnswerCheckerMaker checkerType = makers.get(checkerName);
+		if(checkerType == null)
+			return new CaseInsensitiveAnswerChecker(input);
+		
+		return checkerType.make(input.substring(end+1));
+	}
+}

--- a/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
+++ b/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
@@ -12,7 +12,9 @@ public interface AnswerCheckerMaker {
 		new AbstractMap.SimpleImmutableEntry<>("case_insensitive", CaseInsensitiveAnswerChecker::new),
 		new AbstractMap.SimpleImmutableEntry<>("literal", LiteralAnswerChecker::new),
 		new AbstractMap.SimpleImmutableEntry<>("cs", CaseSensitiveAnswerChecker::new),
-		new AbstractMap.SimpleImmutableEntry<>("case_sensitive", CaseSensitiveAnswerChecker::new)
+		new AbstractMap.SimpleImmutableEntry<>("case_sensitive", CaseSensitiveAnswerChecker::new),
+		new AbstractMap.SimpleImmutableEntry<>("multi", MultipleAnswerCheckers::new),
+		new AbstractMap.SimpleImmutableEntry<>("multiple", MultipleAnswerCheckers::new)
 	);
 
 	public static AnswerChecker parseAnswer(String input) {

--- a/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
+++ b/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
@@ -3,6 +3,8 @@ package nanoquiz.checker;
 import java.util.AbstractMap;
 import java.util.Map;
 
+import nanoquiz.Main;
+
 @FunctionalInterface
 public interface AnswerCheckerMaker {
 	AnswerChecker make(String correctAnswer);
@@ -23,13 +25,17 @@ public interface AnswerCheckerMaker {
 			return new CaseInsensitiveAnswerChecker(input);
 
 		int end = input.indexOf(')');
-		if(end == -1)
+		if(end == -1) {
+			Main.log.warning(()->"Question has an opening bracket but no closing one.");
 			return new CaseInsensitiveAnswerChecker(input);
+		}
 		
 		String checkerName = input.substring(1, end).toLowerCase();
 		AnswerCheckerMaker checkerType = makers.get(checkerName);
-		if(checkerType == null)
+		if(checkerType == null) {
+			Main.log.warning(()->"Unknown answer checker: \"" + checkerName + "\".");
 			return new CaseInsensitiveAnswerChecker(input);
+		}
 		
 		return checkerType.make(input.substring(end+1));
 	}

--- a/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
+++ b/src/main/java/nanoquiz/checker/AnswerCheckerMaker.java
@@ -14,7 +14,8 @@ public interface AnswerCheckerMaker {
 		new AbstractMap.SimpleImmutableEntry<>("cs", CaseSensitiveAnswerChecker::new),
 		new AbstractMap.SimpleImmutableEntry<>("case_sensitive", CaseSensitiveAnswerChecker::new),
 		new AbstractMap.SimpleImmutableEntry<>("multi", MultipleAnswerCheckers::new),
-		new AbstractMap.SimpleImmutableEntry<>("multiple", MultipleAnswerCheckers::new)
+		new AbstractMap.SimpleImmutableEntry<>("multiple", MultipleAnswerCheckers::new),
+		new AbstractMap.SimpleImmutableEntry<>("renamed", RenamedAnswerChecker::new)
 	);
 
 	public static AnswerChecker parseAnswer(String input) {

--- a/src/main/java/nanoquiz/checker/CaseSensitiveAnswerChecker.java
+++ b/src/main/java/nanoquiz/checker/CaseSensitiveAnswerChecker.java
@@ -1,0 +1,19 @@
+package nanoquiz.checker;
+
+public class CaseSensitiveAnswerChecker implements AnswerChecker {
+	String correctAnswer;
+
+    public CaseSensitiveAnswerChecker(String correctAnswer) {
+        this.correctAnswer = correctAnswer.strip();
+    }
+
+    @Override
+    public boolean check(String userAnswer) {
+        return correctAnswer.equals(userAnswer.strip());
+    }
+
+    @Override
+    public String getCorrectAnswer() {
+        return correctAnswer;
+    }
+}

--- a/src/main/java/nanoquiz/checker/LiteralAnswerChecker.java
+++ b/src/main/java/nanoquiz/checker/LiteralAnswerChecker.java
@@ -1,0 +1,20 @@
+package nanoquiz.checker;
+
+public class LiteralAnswerChecker implements AnswerChecker {
+	String correctAnswer;
+
+	public LiteralAnswerChecker(String correctAnswer) {
+		this.correctAnswer = correctAnswer;
+	}
+
+	@Override
+	public boolean check(String userAnswer) {
+		return correctAnswer.equals(userAnswer);
+	}
+
+	@Override
+	public String getCorrectAnswer() {
+		return correctAnswer;
+	}
+	
+}

--- a/src/main/java/nanoquiz/checker/MultipleAnswerCheckers.java
+++ b/src/main/java/nanoquiz/checker/MultipleAnswerCheckers.java
@@ -1,0 +1,32 @@
+package nanoquiz.checker;
+
+public class MultipleAnswerCheckers implements AnswerChecker {
+	private AnswerChecker[] checkers;
+
+	public MultipleAnswerCheckers(String data) {
+		String[] elements = data.split(";");
+		checkers = new AnswerChecker[elements.length];
+		for(int i = 0; i < elements.length; i++) {
+			if(elements[i].startsWith(" "))
+				elements[i] = elements[i].substring(1);
+			checkers[i] = AnswerCheckerMaker.parseAnswer(elements[i]);
+		}
+	}
+
+	@Override
+	public boolean check(String userAnswer) {
+		for(AnswerChecker checker: checkers) {
+			if (checker.check(userAnswer)) {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+
+	@Override
+	public String getCorrectAnswer() {
+		return checkers[0].getCorrectAnswer();
+	}
+	
+}

--- a/src/main/java/nanoquiz/checker/RenamedAnswerChecker.java
+++ b/src/main/java/nanoquiz/checker/RenamedAnswerChecker.java
@@ -1,0 +1,32 @@
+package nanoquiz.checker;
+
+import nanoquiz.Main;
+
+public class RenamedAnswerChecker implements AnswerChecker {
+	private AnswerChecker checker;
+	private String answerName;
+
+	public RenamedAnswerChecker(String input) {
+		String[] parts = input.split(";", 2);
+		answerName = parts[0].strip();
+		if(parts.length == 1) { // incorrect format
+			Main.log.warning(()->"Incorrect format for \"renamed\" answer checker");
+			checker = new CaseInsensitiveAnswerChecker("");
+		} else {
+			if(parts[1].startsWith(" "))
+				parts[1] = parts[1].substring(1);
+			checker = AnswerCheckerMaker.parseAnswer(parts[1]);
+		}
+	}
+
+	@Override
+	public boolean check(String userAnswer) {
+		return checker.check(userAnswer);
+	}
+
+	@Override
+	public String getCorrectAnswer() {
+		return answerName;
+	}
+	
+}


### PR DESCRIPTION
Allow for multiple ways to check answers and other utilities. Answer checkers included:
- `case_insensitive` (`ci`) - the old one
- `literal`
- `case_sensitive` (`cs`)
- `multiple` (`multi`)
- `renamed`